### PR TITLE
Same Page Preview does not reload on change

### DIFF
--- a/src/MaxAgeDecider.php
+++ b/src/MaxAgeDecider.php
@@ -73,6 +73,12 @@ class MaxAgeDecider implements EventSubscriberInterface, MaxAgeInterface
             return $explicit;
         }
 
+        if ($request->attributes->has('node_preview')) {
+            return $explicit + [
+                'maxage' => 0,
+            ];
+        }
+
         if (
             $request->attributes->has('_smaxage')
             || $request->attributes->has('_maxage')


### PR DESCRIPTION
The Same Page Preview module renders the node preview route in an iframe next to the node edit form and automatically reloads it after a form field changes. The problem is that changes are not coming through after the iframe is reloaded, unless the developer console is open with the 'Disable HTTP cache' option enabled. This is how I found the issue: node preview responses shouldn't get a maxage, otherwise the browser will cache these responses. s-maxage and wm-s-maxages doesn't seem to be relevant here, so I didn't touch those.