### PR TITLE
Stop caching preview_link preview routes

### DIFF
--- a/src/MaxAgeDecider.php
+++ b/src/MaxAgeDecider.php
@@ -71,14 +71,14 @@ class MaxAgeDecider implements EventSubscriberInterface, MaxAgeInterface
     {
         $explicit = $this->explicitMaxAges ?: [];
 
-        if (isset($explicit['maxage']) || isset($explicit['s-maxage'])) {
-            return $explicit;
-        }
-
-        if ($request->attributes->has('node_preview')) {
-            return $explicit + [
+        if ($this->isPreview($request)) {
+            return [
                 'maxage' => 0,
             ];
+        }
+
+        if (isset($explicit['maxage']) || isset($explicit['s-maxage'])) {
+            return $explicit;
         }
 
         if (
@@ -162,5 +162,11 @@ class MaxAgeDecider implements EventSubscriberInterface, MaxAgeInterface
         );
 
         return $event->getEntity();
+    }
+
+    protected function isPreview(Request $request): bool
+    {
+        return $request->attributes->has('node_preview')
+            || $request->attributes->has('preview_token');
     }
 }


### PR DESCRIPTION
Stop caching the preview route of the [Preview Link module](https://www.drupal.org/project/preview_link). Also changed that just an empty max-age is returned for the standard node preview route, without merging with the other explicit values.