### PR TITLE
Mark http responses with status codes `300`, `301`, `302` and `410` c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-alpha4] - 2023-10-30
+### Fixed
+- Mark http responses with status codes `300`, `301`, `302` and `410` cacheable
+- Don't cache node preview responses
+- Don't cache responses of the [drupal/preview_link](https://www.drupal.org/project/preview_link) module
+
 ## [1.0.0-alpha3] - 2023-07-19
 ### Added
 - Support `stale-while-revalidate` and `stale-if-error` cache control header

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -18,7 +18,11 @@ class Validation implements EventSubscriberInterface
     protected $cacheableStatusCodes = [
         Response::HTTP_OK => true,
         Response::HTTP_NON_AUTHORITATIVE_INFORMATION => true,
+        Response::HTTP_MULTIPLE_CHOICES => true,
+        Response::HTTP_MOVED_PERMANENTLY => true,
+        Response::HTTP_FOUND => true,
         Response::HTTP_NOT_FOUND => true,
+        Response::HTTP_GONE => true,
     ];
 
     /** @var array<string, bool> */


### PR DESCRIPTION
Mark http responses with status codes `300`, `301`, `302` and `410` cacheable

See Symfony's isCacheable() method:
https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/HttpFoundation/Response.php#L569-L580